### PR TITLE
Add dashboard controls, theme toggle and dynamic charts with loading state

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,17 @@
                     <div class="new-value">+0</div>
                    </div>
                 </div>
+
+                <div class="dashboard-controls">
+                    <button id="refresh-data" class="control-btn" type="button">Refresh Data</button>
+                    <button id="toggle-theme" class="control-btn" type="button">Toggle Theme</button>
+                    <span id="last-updated" class="last-updated">Last updated: waiting for data</span>
+                </div>
+
+                <div id="loading-indicator" class="loading-indicator hide" aria-live="polite">
+                    Fetching latest country data...
+                </div>
+
                 <div class="chart">
                     <canvas id="axes_line_chart"></canvas>
                 </div>

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -144,6 +144,41 @@ main{
     font-size: 1.3em;
 }
 
+.dashboard-controls{
+    width: 80%;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: #ffffff;
+    flex-wrap: wrap;
+}
+
+.control-btn{
+    background: #52527a;
+    color: #fff;
+    border: 1px solid #6b6ba1;
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.control-btn:hover{
+    background: #6b6ba1;
+}
+
+.last-updated{
+    font-size: 0.95rem;
+    color: #d8d8e8;
+}
+
+.loading-indicator{
+    width: 80%;
+    margin: 10px auto 0;
+    color: #9de3da;
+    font-size: 0.95rem;
+}
+
 
 /* -------- CHART -------- */
 .chart{
@@ -274,6 +309,25 @@ main{
         flex-direction: column;
         align-self: start;
     }
+}
+
+body.light-theme .stats{
+    background-image: linear-gradient(rgba(248,248,248,0.96), rgba(248,248,248,0.96)) , url('../../resources/img/bg.jpg');
+}
+
+body.light-theme .latest-report,
+body.light-theme .dashboard-controls,
+body.light-theme .loading-indicator,
+body.light-theme .topcountries .name{
+    color: #1d1d1d;
+}
+
+body.light-theme .total-cases .value{
+    color: #111;
+}
+
+body.light-theme .new-value{
+    color: #333;
 }
 .containers{
     width:90%; 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,161 +6,288 @@ const recovered_element = document.querySelector(".recovered .value");
 const new_recovered_element = document.querySelector(".recovered .new-value");
 const deaths_element = document.querySelector(".deaths .value");
 const new_deaths_element = document.querySelector(".deaths .new-value");
+const chartElement = document.getElementById("axes_line_chart");
+const barChartElement = document.getElementById("bar_chart");
+const refreshButton = document.getElementById("refresh-data");
+const toggleThemeButton = document.getElementById("toggle-theme");
+const lastUpdatedElement = document.getElementById("last-updated");
+const loadingIndicator = document.getElementById("loading-indicator");
+const searchInput = document.getElementById("search-input");
+const searchCountryContainer = document.querySelector(".search-country");
 
-const ctx = document.getElementById("axes_line_chart").getContext("2d");
+const ctx = chartElement ? chartElement.getContext("2d") : null;
+
+function isLightThemeEnabled() {
+  return document.body.classList.contains("light-theme");
+}
+
+function getChartTextColor() {
+  return isLightThemeEnabled() ? "#1d1d1d" : "#ffffff";
+}
 
 // APP VARIABLES
-let app_data = [],
-  cases_list = [],
-  recovered_list = [],
-  deaths_list = [],
-  deaths = [],
-  formatedDates = [];
+let cases_list = [];
+let recovered_list = [];
+let deaths_list = [];
+let dates = [];
+let formatedDates = [];
 
-// GET USERS COUNTRY CODE
-let country_code = geoplugin_countryCode();
-let user_country;
-country_list.forEach((country) => {
-  if (country.code == country_code) {
-    user_country = country.name;
-  }
-});
-
-/* ---------------------------------------------- */
-/*                     FETCH API                  */
-/* ---------------------------------------------- */
-function fetchData(country) {
-  user_country = country;
-  country_name_element.innerHTML = "Loading...";
-
-  (cases_list = []),
-    (recovered_list = []),
-    (deaths_list = []),
-    (dates = []),
-    (formatedDates = []);
-
-  var requestOptions = {
-    method: "GET",
-    redirect: "follow",
-  };
-
-  const api_fetch = async (country) => {
-    const covidConfirmedRes = await fetch(
-      "https://api.covid19api.com/total/country/" +
-        country +
-        "/status/confirmed",
-      requestOptions
-    );
-    const covidConfirmedJson = await covidConfirmedRes.json();
-    covidConfirmedJson?.forEach((entry) => {
-      dates.push(entry.Date);
-      cases_list.push(entry.Cases);
-    });
-
-    const covidRecoveredRes = await fetch(
-      "https://api.covid19api.com/total/country/" +
-        country +
-        "/status/recovered",
-      requestOptions
-    );
-    const covidRecoveredData = await covidRecoveredRes.json();
-
-    covidRecoveredData?.forEach((entry) => {
-      recovered_list.push(entry.Cases);
-    });
-
-    const covidDeathRes = await fetch(
-      "https://api.covid19api.com/total/country/" + country + "/status/deaths",
-      requestOptions
-    );
-    const covidDeathData = await covidDeathRes.json();
-
-    covidDeathData.forEach((entry) => {
-      deaths_list.push(entry.Cases);
-    });
-
-    updateUI();
-  };
-
-  api_fetch(country);
+// Prevent runtime errors on pages that do not have dashboard canvases.
+if (ctx && barChartElement) {
+  initializeDashboard();
 }
 
-fetchData(user_country);
+function initializeDashboard() {
+  // GET USERS COUNTRY CODE
+  let country_code = geoplugin_countryCode();
+  let user_country = "India";
 
-// UPDATE UI FUNCTION
-function updateUI() {
-  updateStats();
-  axesLinearChart();
-}
-
-function updateStats() {
-  const total_cases = cases_list[cases_list.length - 1];
-  const new_confirmed_cases = total_cases - cases_list[cases_list.length - 2];
-
-  const total_recovered = recovered_list[recovered_list.length - 1];
-  const new_recovered_cases =
-    total_recovered - recovered_list[recovered_list.length - 2];
-
-  const total_deaths = deaths_list[deaths_list.length - 1];
-  const new_deaths_cases = total_deaths - deaths_list[deaths_list.length - 2];
-
-  country_name_element.innerHTML = user_country;
-  total_cases_element.innerHTML = total_cases;
-  new_cases_element.innerHTML = `+${new_confirmed_cases}`;
-  recovered_element.innerHTML = total_recovered;
-  new_recovered_element.innerHTML = `+${new_recovered_cases}`;
-  deaths_element.innerHTML = total_deaths;
-  new_deaths_element.innerHTML = `+${new_deaths_cases}`;
-
-  // format dates
-  dates.forEach((date) => {
-    formatedDates.push(formatDate(date));
+  country_list.forEach((country) => {
+    if (country.code === country_code) {
+      user_country = country.name;
+    }
   });
-}
 
-// UPDATE CHART
-let my_chart;
-function axesLinearChart() {
-  if (my_chart) {
-    my_chart.destroy();
+  fetchData(user_country);
+  setupInteractiveControls();
+
+  function setupInteractiveControls() {
+    if (refreshButton) {
+      refreshButton.addEventListener("click", () => fetchData(user_country));
+    }
+
+    if (toggleThemeButton) {
+      toggleThemeButton.addEventListener("click", () => {
+        document.body.classList.toggle("light-theme");
+
+        axesLinearChart();
+        if (barChart) {
+          renderTopCountriesChart(topCountriesData);
+        }
+      });
+    }
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "/" && searchInput) {
+        event.preventDefault();
+        searchInput.focus();
+      }
+
+      if (event.key === "Escape" && searchCountryContainer) {
+        searchCountryContainer.classList.add("hide");
+      }
+    });
   }
 
-  my_chart = new Chart(ctx, {
-    type: "line",
-    data: {
-      datasets: [
-        {
-          label: "Cases",
-          data: cases_list,
-          fill: false,
-          borderColor: "#FFF",
-          backgroundColor: "#FFF",
-          borderWidth: 1,
+  /* ---------------------------------------------- */
+  /*                     FETCH API                  */
+  /* ---------------------------------------------- */
+  async function fetchData(country) {
+    user_country = country;
+    if (country_name_element) {
+      country_name_element.innerHTML = "Loading...";
+    }
+
+    cases_list = [];
+    recovered_list = [];
+    deaths_list = [];
+    dates = [];
+    formatedDates = [];
+
+    const requestOptions = {
+      method: "GET",
+      redirect: "follow",
+    };
+
+    try {
+      setLoadingState(true);
+      const covidConfirmedRes = await fetch(
+        `https://api.covid19api.com/total/country/${country}/status/confirmed`,
+        requestOptions
+      );
+      const covidConfirmedJson = await covidConfirmedRes.json();
+      covidConfirmedJson?.forEach((entry) => {
+        dates.push(entry.Date);
+        cases_list.push(entry.Cases);
+      });
+
+      const covidRecoveredRes = await fetch(
+        `https://api.covid19api.com/total/country/${country}/status/recovered`,
+        requestOptions
+      );
+      const covidRecoveredData = await covidRecoveredRes.json();
+      covidRecoveredData?.forEach((entry) => {
+        recovered_list.push(entry.Cases);
+      });
+
+      const covidDeathRes = await fetch(
+        `https://api.covid19api.com/total/country/${country}/status/deaths`,
+        requestOptions
+      );
+      const covidDeathData = await covidDeathRes.json();
+      covidDeathData?.forEach((entry) => {
+        deaths_list.push(entry.Cases);
+      });
+
+      await updateTopCountriesChart(requestOptions);
+      updateUI();
+      updateLastUpdated();
+    } catch (error) {
+      if (country_name_element) {
+        country_name_element.innerHTML = "Could not load data";
+      }
+    } finally {
+      setLoadingState(false);
+    }
+  }
+
+  // Expose this for countries.js list selections.
+  window.onCountrySelected = fetchData;
+  window.fetchData = fetchData;
+
+  // UPDATE UI FUNCTION
+  function updateUI() {
+    updateStats();
+    axesLinearChart();
+  }
+
+  function updateStats() {
+    const total_cases = cases_list[cases_list.length - 1] || 0;
+    const previous_total_cases = cases_list[cases_list.length - 2] || total_cases;
+    const new_confirmed_cases = total_cases - previous_total_cases;
+
+    const total_recovered = recovered_list[recovered_list.length - 1] || 0;
+    const previous_total_recovered = recovered_list[recovered_list.length - 2] || total_recovered;
+    const new_recovered_cases = total_recovered - previous_total_recovered;
+
+    const total_deaths = deaths_list[deaths_list.length - 1] || 0;
+    const previous_total_deaths = deaths_list[deaths_list.length - 2] || total_deaths;
+    const new_deaths_cases = total_deaths - previous_total_deaths;
+
+    country_name_element.innerHTML = user_country;
+    total_cases_element.innerHTML = total_cases.toLocaleString();
+    new_cases_element.innerHTML = `+${new_confirmed_cases.toLocaleString()}`;
+    recovered_element.innerHTML = total_recovered.toLocaleString();
+    new_recovered_element.innerHTML = `+${new_recovered_cases.toLocaleString()}`;
+    deaths_element.innerHTML = total_deaths.toLocaleString();
+    new_deaths_element.innerHTML = `+${new_deaths_cases.toLocaleString()}`;
+
+    dates.forEach((date) => {
+      formatedDates.push(formatDate(date));
+    });
+  }
+
+  // UPDATE CHART
+  let my_chart;
+  let topCountriesData = [];
+  function axesLinearChart() {
+    if (my_chart) {
+      my_chart.destroy();
+    }
+
+    my_chart = new Chart(ctx, {
+      type: "line",
+      data: {
+        datasets: [
+          {
+            label: "Cases",
+            data: cases_list,
+            fill: false,
+            borderColor: "#FFF",
+            backgroundColor: "#FFF",
+            borderWidth: 1,
+          },
+          {
+            label: "Recovered",
+            data: recovered_list,
+            fill: false,
+            borderColor: "#009688",
+            backgroundColor: "#009688",
+            borderWidth: 1,
+          },
+          {
+            label: "Deaths",
+            data: deaths_list,
+            fill: false,
+            borderColor: "#f44336",
+            backgroundColor: "#f44336",
+            borderWidth: 1,
+          },
+        ],
+        labels: formatedDates,
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        legend: {
+          labels: {
+            fontColor: getChartTextColor(),
+          },
         },
-        {
-          label: "Recovered",
-          data: recovered_list,
-          fill: false,
-          borderColor: "#009688",
-          backgroundColor: "#009688",
-          borderWidth: 1,
+        scales: {
+          xAxes: [{ ticks: { fontColor: getChartTextColor() } }],
+          yAxes: [{ ticks: { fontColor: getChartTextColor() } }],
         },
-        {
-          label: "Deaths",
-          data: deaths_list,
-          fill: false,
-          borderColor: "#f44336",
-          backgroundColor: "#f44336",
-          borderWidth: 1,
+      },
+    });
+  }
+
+  let barChart;
+  async function updateTopCountriesChart(requestOptions) {
+    const summaryRes = await fetch("https://api.covid19api.com/summary", requestOptions);
+    const summaryData = await summaryRes.json();
+
+    topCountriesData = (summaryData.Countries || [])
+      .sort((a, b) => b.TotalConfirmed - a.TotalConfirmed)
+      .slice(0, 10);
+
+    renderTopCountriesChart(topCountriesData);
+  }
+
+  function renderTopCountriesChart(topCountries) {
+    if (barChart) {
+      barChart.destroy();
+    }
+
+    barChart = new Chart(barChartElement, {
+      type: "bar",
+      data: {
+        labels: topCountries.map((country) => country.Country),
+        datasets: [
+          {
+            label: "Confirmed",
+            data: topCountries.map((country) => country.TotalConfirmed),
+            backgroundColor: "#c0392b",
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        legend: {
+          labels: {
+            fontColor: getChartTextColor(),
+          },
         },
-      ],
-      labels: formatedDates,
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-    },
-  });
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                beginAtZero: true,
+                fontColor: getChartTextColor(),
+              },
+            },
+          ],
+          xAxes: [
+            {
+              ticks: {
+                fontColor: getChartTextColor(),
+              },
+            },
+          ],
+        },
+      },
+    });
+  }
 }
 
 // FORMAT DATES
@@ -171,6 +298,7 @@ const monthsNames = [
   "Apr",
   "May",
   "Jun",
+  "Jul",
   "Aug",
   "Sep",
   "Oct",
@@ -179,34 +307,24 @@ const monthsNames = [
 ];
 
 function formatDate(dateString) {
-  let date = new Date(dateString);
-
-  return `${date.getDate()} ${monthsNames[date.getMonth() - 1]}`;
+  const date = new Date(dateString);
+  return `${date.getDate()} ${monthsNames[date.getMonth()]}`;
 }
 
-
-//TOP 10 Countries Bar Chart (Still Static Data)
-const barcanvas = document.querySelector('#bar_chart');
-let barChart = new Chart(barcanvas,{
-  type: 'bar',
-  data: {
-    labels: ['US', 'India', 'Brazil', 'United Kingdom', 'Russia', 'France', 'Turkey', 'Iran', 'Argentina', 'Spain'],
-    datasets: [{
-      label: 'Confirmed',
-      data: [
-        45135620,
-        33935309,
-        21550730,
-        8081300,
-        7746718,
-        7387537,
-        7047786,
-        5683980,
-        5265058,
-        4973619,
-      ],
-      backgroundColor: 'red'
-    }]
-    
+function updateLastUpdated() {
+  if (!lastUpdatedElement) {
+    return;
   }
-})
+
+  lastUpdatedElement.textContent = `Last updated: ${new Date().toLocaleString()}`;
+}
+
+function setLoadingState(isLoading) {
+  if (loadingIndicator) {
+    loadingIndicator.classList.toggle("hide", !isLoading);
+  }
+
+  if (refreshButton) {
+    refreshButton.disabled = isLoading;
+  }
+}

--- a/resources/js/countries.js
+++ b/resources/js/countries.js
@@ -226,7 +226,7 @@ function createCountryList(){
         }
 
         document.getElementById(`${ul_list_id}`).innerHTML += `
-            <li onclick="fetchData('${country.name}')" id="${country.name}">
+            <li data-country="${country.name}" id="${country.name}">
             ${country.name}
             </li>
         `;
@@ -234,41 +234,61 @@ function createCountryList(){
 }
 
 let num_of_ul_lists = 3;
-createCountryList();
 
-// SHOW/HIDE THE COUTRY LIST ON CLICK EVENT
-chang_country_btn.addEventListener("click", function(){
-    input.value = "";
-    resetCountryList();
-    search_country_element.classList.toggle("hide");
-    search_country_element.classList.add("fadeIn");
-});
+if (search_country_element && country_list_element && chang_country_btn && close_list_btn && input) {
+    createCountryList();
 
-close_list_btn.addEventListener("click", function(){
-    search_country_element.classList.toggle("hide");
-});
+    // SHOW/HIDE THE COUTRY LIST ON CLICK EVENT
+    chang_country_btn.addEventListener("click", function(){
+        input.value = "";
+        resetCountryList();
+        search_country_element.classList.toggle("hide");
+        search_country_element.classList.add("fadeIn");
+    });
 
-country_list_element.addEventListener("click", function(){
-    search_country_element.classList.toggle("hide");
-});
+    close_list_btn.addEventListener("click", function(){
+        search_country_element.classList.toggle("hide");
+    });
 
-// COUNTRY FILTER
-/* input event fires up whenever the value of the input changes */
-input.addEventListener("input", function(){
-    let value = input.value.toUpperCase();
+    country_list_element.addEventListener("click", function(event){
+        const countryItem = event.target.closest('li[data-country]');
 
-    country_list.forEach( country => {
-        if( country.name.toUpperCase().startsWith(value)){
-            document.getElementById(country.name).classList.remove("hide");
-        }else{
-            document.getElementById(country.name).classList.add("hide");
+        if (!countryItem) {
+            return;
         }
+
+        const selectedCountry = countryItem.getAttribute('data-country');
+
+        if (typeof window.onCountrySelected === 'function') {
+            window.onCountrySelected(selectedCountry);
+        } else if (typeof window.fetchData === 'function') {
+            window.fetchData(selectedCountry);
+        }
+
+        search_country_element.classList.add("hide");
+    });
+
+    // COUNTRY FILTER
+    /* input event fires up whenever the value of the input changes */
+    input.addEventListener("input", function(){
+        let value = input.value.toUpperCase();
+
+        country_list.forEach( country => {
+            if( country.name.toUpperCase().startsWith(value)){
+                document.getElementById(country.name).classList.remove("hide");
+            }else{
+                document.getElementById(country.name).classList.add("hide");
+            }
+        })
     })
-})
+}
 
 // RESET COUNTRY LIST (SHOW ALL THE COUNTRIES )
 function resetCountryList(){
     country_list.forEach( country => {
-        document.getElementById(country.name).classList.remove("hide");
+        const countryElement = document.getElementById(country.name);
+        if (countryElement) {
+            countryElement.classList.remove("hide");
+        }
     })
 }


### PR DESCRIPTION
### Motivation
- Improve dashboard usability by adding explicit controls for refreshing data and toggling theme, and provide feedback during network requests. 
- Replace static top-countries chart and static country selection with dynamic fetching and interactive selection to show live data.
- Harden dashboard scripts to avoid runtime errors on pages that do not include chart elements.

### Description
- Added UI elements in `index.html` for refresh and theme toggle (`#refresh-data`, `#toggle-theme`), a `#last-updated` label and a `#loading-indicator` message, and wired new CSS rules in `resources/css/style.css` for those elements and a light theme variant. 
- Reworked `resources/js/app.js` to initialize the dashboard only when chart canvases exist, modularized logic into `initializeDashboard`, `fetchData`, `updateUI`, `updateStats`, `axesLinearChart`, `updateTopCountriesChart`, `renderTopCountriesChart`, `updateLastUpdated`, and `setLoadingState`, added theme-aware chart text coloring with `getChartTextColor`, and exposed `window.onCountrySelected`/`window.fetchData` for external selection. 
- Replaced static hardcoded top-10 bar chart with dynamic fetch from `https://api.covid19api.com/summary` and rendering of live top countries data. 
- Improved `resources/js/countries.js` to guard DOM access, build the country list with `data-country` attributes, support click delegation to call `window.onCountrySelected`/`window.fetchData`, and robustly reset/hide list items. 

### Testing
- No automated tests were added or executed as part of this change. 
- Basic smoke checks performed during development: dashboard initializes when canvases are present, `Refresh Data` triggers data reload, `Toggle Theme` updates charts' text color, and country selection triggers data fetch; these manual checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0027c7a788331a5f89a828d0f7f7b)